### PR TITLE
csslint with no warning

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -29,7 +29,7 @@ var Stack = require('./stack').Stack,
             var file = info.name.replace(process.cwd(), ''),
                 lint = info.csslint,
                 counter = 0;
-            if (lint.length) {
+            if (!!lint && lint.length) {
                 log.err(file + ' contains ' + lint.length + ' lint errors');
 
                 lint.forEach(function (item) {


### PR DESCRIPTION
When a component css skin generates no warning through csslint, info.csslint is undefined, not empty...
