### PR TITLE
Add "use strict" in function wrapper for rollup to prevent lint error

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -724,7 +724,7 @@ var _rollup = function (mod, name, options, callback) {
     queue.read(files)
         .concat()
         .jsstamp({
-            postfix: "YUI.add('" + modName + "', function (Y, NAME) {}, '@VERSION@'" + stringify(mod.config) + ");\n"
+            postfix: "YUI.add('" + modName + "', function (Y, NAME) {" + (options.strict ? '"use strict"; ' : "") + "}, '@VERSION@'" + stringify(mod.config) + ");\n"
         })
         .replace(replaceOptions)
         .log('writing rollup file ' + path.join(fileName, fileName + '-debug.js'))


### PR DESCRIPTION
Seems a bit odd that jslint complains about missing "strict" in an empty function body, but I suppose it has its reasons. This will silence that error for the rollup wrapper added at the end of the build file by putting the string in when strict mode is enabled in the build options.
