### PR TITLE
Allow shifter to run recursively to cater for a distributed module layout

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -14,6 +14,7 @@ var nopt = require('nopt'),
         fail: Boolean,
         modules: Array,
         walk: Boolean,
+        recursive: Boolean,
         'lint-stderr': Boolean,
         watch: Boolean,
         quiet: Boolean,
@@ -84,6 +85,7 @@ var setDefaults = function(parsed) {
     parsed.clean = (parsed.clean === undefined || parsed.clean === false) ? false : true;
     parsed['lint-stderr'] = (parsed['lint-stderr'] === undefined || parsed['lint-stderr'] === false) ? false : true;
     parsed.progress = (parsed.progress === undefined || parsed.progress === false) ? false : true;
+    parsed.recursive = (parsed.recursive === undefined || parsed.recursive === false) ? false : true;
 
     //Other defaults
     parsed['build-dir'] = parsed['build-dir'] || '../../build';

--- a/lib/help.js
+++ b/lib/help.js
@@ -75,6 +75,7 @@ if (args.help) {
     console.log('   --fail                  Fail the build if lint fails');
     console.log('   --no-lint               Skip JSlint, you better know what you are doing!');
     console.log('   --lint-stderr           Force lint output to stderr instead of stdout');
+    console.log('   --recursive             When running a walk, look at directories recursively');
     console.log('   --no-global-config      Do not search for a .shifter.json file up the working path');
     console.log('CLI Replacers:');
     console.log('   You can pass --replace-??=?? and shifter will attempt to replace these strings during the build');

--- a/lib/walk.js
+++ b/lib/walk.js
@@ -26,7 +26,8 @@ exports.run = function (options) {
         bar,
         ProgressBar,
         i,
-        args = [];
+        args = [],
+        checkDirectory;
 
     if (options.progress) {
         ProgressBar = require('progress'),
@@ -82,18 +83,29 @@ exports.run = function (options) {
         log.info('using ' + args.join(' '));
     }
 
-    fs.readdir(shifter.cwd(), modStack.add(function (err, dirs) {
-        dirs.forEach(function (mod) {
-            var p = path.join(shifter.cwd(), mod);
-            exists(path.join(p, 'build.json'), modStack.add(function (yes) {
-                if (yes) {
-                    if (!options.modules || has(options.modules, mod)) {
-                        mods.push(mod);
+    checkDirectory = function(startdir, workingdir) {
+        fs.readdir(workingdir, modStack.add(function (err, dirs) {
+            dirs.forEach(function (mod) {
+                var p = path.join(workingdir, mod);
+                exists(path.join(p, 'build.json'), modStack.add(function (yes) {
+                    var relative, stat;
+                    if (yes) {
+                        if (!options.modules || has(options.modules, mod)) {
+                            relative = workingdir.replace(startdir, '');
+                            mods.push(path.join(relative, mod));
+                        }
+                    } else if (options.recursive) {
+                        stat = fs.statSync(p);
+                        if (stat.isDirectory()) {
+                            checkDirectory(startdir, p);
+                        }
                     }
-                }
-            }));
-        });
-    }));
+                }));
+            });
+        }));
+    };
+
+    checkDirectory(shifter.cwd(), shifter.cwd());
 
     modStack.done(function () {
         if (!mods.length) {

--- a/tests/args.js
+++ b/tests/args.js
@@ -11,6 +11,7 @@ var argsTests = {
     '--strict': 'strict',
     '--cache': 'cache',
     '--walk': 'walk',
+    '--recursive': 'recursive',
     '--watch': 'watch',
     '--quiet': 'quiet',
     '--ant': 'ant',


### PR DESCRIPTION
As discussed in http://yuilibrary.com/forum/viewtopic.php?f=18&t=11472
there are times (though admittedly relatively few) where modules may be
dispersed throughout a project and not limited to a single src directory.

The --recursive option tries to find any directory with a build.json
underneath it.
