### PR TITLE
Make it possible to configure jsstamp at a module level instead of only globally

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -638,7 +638,8 @@ var build = function (mod, name, options, callback) {
     coverageType = (options.istanbul) ? 'istanbul' : 'yuitest';
     lintFail = options.fail;
     lintSTDError = options['lint-stderr'];
-    mod.stamp = options.jsstamp;
+    mod.stamp = mod.shifter && typeof mod.shifter.jsstamp === 'boolean' ? mod.shifter.jsstamp : options.jsstamp;
+
 
     _build = stack.add(function() {
         if (mod.jsfiles && mod.jsfiles.length) {


### PR DESCRIPTION
Using the config structure already discussed in the build.json object reference.
