### PR TITLE
Add callback support to walk.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -155,7 +155,7 @@ exports.init = function (opts, initCallback) {
         } else {
             if (options.walk) {
                 walk = require('./walk');
-                walk.run(options);
+                walk.run(options, initCallback);
             } else {
                 log.warn('no ' + buildFileName + ' file, downshifting to convert ant files');
                 ant = require('./ant');

--- a/lib/walk.js
+++ b/lib/walk.js
@@ -14,7 +14,7 @@ var log = require('./log'),
         });
     };
 
-exports.run = function (options) {
+exports.run = function (options, callback) {
     if (!log.isTTY) {
         options.progress = false;
     }
@@ -159,6 +159,8 @@ exports.run = function (options) {
                     console.log('   ', log.color(mod, 'red'));
                 });
                 process.exit(1);
+            } else if (typeof callback === 'function') {
+                callback();
             }
         });
     });


### PR DESCRIPTION
``` javascript
var shifter = require('shifter');

shifter.init({ cwd: '/some/valid/path' }, function() {
  console.log('== shifter finished ==');
});
```

**== shifter finished ==** logged after shifter completes.

``` javascript
var shifter = require('shifter');

shifter.init({ cwd: '/some/valid/path', walk: true }, function() {
  console.log('== shifter finished ==');
});
```

Callback never executed.
