### PR TITLE
JS lint errors not colored when shifter run with --walk

### DIFF
--- a/lib/walk.js
+++ b/lib/walk.js
@@ -124,7 +124,7 @@ exports.run = function (options) {
                     args.unshift(util.shifter);
                     child = spawn(process.execPath, args, {
                         cwd: path.join(shifter.cwd(), mod),
-                        stdio: ['ignore', 'ignore', process.stderr]
+                        stdio: [process.stdin, 'ignore', process.stderr]
                     });
                     child.on('exit', stack.add(function (code) {
                         if (options.progress) {


### PR DESCRIPTION
If I run `shifter --walk` all the JS Lint output is not appropriately colored ([err] comes out in white) this makes it hard to spot the errors in the terminal.

Have tested this in Windows console. Running `shifter` without walking causes the output to come out correctly.

This is because the stdio for the spawned shifter process is being set to 'ignore' for stdin (which is the basis of the color check in `log.js`). This can be fixed with the below code by passing in `process.stdin` to the spawned process (line 127 of walk.js). However I'm not sure what the impact of passing stdin to the child process would be?

```
                    child = spawn(process.execPath, args, {
                        cwd: path.join(shifter.cwd(), mod),
                        stdio: [process.stdin, 'ignore', process.stderr]
                    });
```
