### PR TITLE
Adding support for build.json "replace" function for CSS-Files

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -224,7 +224,8 @@ var buildCSS = function (mod, name, callback) {
     var queue = new Queue({
         logger: log,
         registry: registry
-    });
+    }),
+      replacers = [];
 
     queue.read(resolve(mod.cssfiles, 'css'))
         .concat()
@@ -232,6 +233,16 @@ var buildCSS = function (mod, name, callback) {
 
     if (defaultLint && cssLint) {
         queue.csslint(cssLintConfig);
+    }
+
+    if (mod.replace) {
+      Object.keys(mod.replace).forEach(function (key) {
+        replacers.push({
+          regex: key,
+          replace: mod.replace[key]
+        });
+      });
+      queue.replace(replacers);
     }
 
     queue.cssstamp({


### PR DESCRIPTION
I needed replace function for CSS-files, defined in build.json. With this change it should be possible to use the syntax for CSS-files as you do for JS-files.

sample code: 

``` json
...
, "p-gui-css-styles": {
      "cssfiles": [
        "style.css"
      ] 
      , "replace": {
        "@amber-off-16@": "background-position: -310px -46px;"
        , "@amber-on-16@": "background-position: -161px -17px;"
      }
      , "config" : {
        "type": "css"
      }
    }   
...
```
