### PR TITLE
Inclusion of --build-dir in args breaks recursive walk

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -91,7 +91,13 @@ var setDefaults = function(parsed) {
     parsed.recursive = (parsed.recursive === undefined || parsed.recursive === false) ? false : true;
 
     //Other defaults
-    parsed['build-dir'] = parsed['build-dir'] || (parsed.walk ? '../build' : '../../build');
+    if (!parsed['build-dir']) {
+        if (parsed.recursive || !parsed.walk) {
+            parsed['build-dir'] = '../../build';
+        } else {
+            parsed['build-dir'] = '../build';
+        }
+    }
 
 
     return parsed;

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,10 @@ exports.init = function (opts, initCallback) {
 
     options.buildFile = buildFile;
     options.buildFileName = buildFileName;
-    options['build-dir'] = path.resolve(exports.cwd(), options['build-dir']);
+    if (!options.recursive) {
+        // The build-dir should not be relative to cwd if running recursively.
+        options['build-dir'] = path.resolve(exports.cwd(), options['build-dir']);
+    }
 
     if (options.version || options.help) {
         require('./help');


### PR DESCRIPTION
I've just updated to the latest build of shifter and tried to build against our code and found that the --recursive argument is now broken. It seems to have been broken since 0.2.16.

When running --recursively, the build directory used to be relative to the src directory, but it is now relative to the location that Shifter is run from.
