### PR TITLE
Added a `verbose` command line option.

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -29,6 +29,7 @@ var nopt = require('nopt'),
         'silent': Boolean,
         'strict': Boolean,
         'version': Boolean,
+        'verbose': Boolean,
         'walk': Boolean,
         'watch': Boolean,
         'yui-module': require('path')
@@ -90,6 +91,8 @@ var setDefaults = function(parsed) {
     parsed['lint-stderr'] = (parsed['lint-stderr'] === undefined || parsed['lint-stderr'] === false) ? false : true;
     parsed.progress = (parsed.progress === undefined || parsed.progress === false) ? false : true;
     parsed.recursive = (parsed.recursive === undefined || parsed.recursive === false) ? false : true;
+    parsed.verbose = (parsed.verbose === undefined || parsed.verbose === false) ? false : true;
+    
 
     if (parsed.recursive) {
         parsed.walk = true;

--- a/lib/help.js
+++ b/lib/help.js
@@ -67,6 +67,9 @@ if (args.help) {
     console.log('                               all other build options accepted here: (--strict, --lint, etc)');
     console.log('   --jsstamp/--no-jsstamp  Should it stamp the JS with the YUI.add wrapper, defaults to --stamp');
     console.log('   --istanbul              Use Istanbul code coverage instead of YUITest for coverage build');
+    console.log('   --quiet                 Show only the number of issues for each file');
+    console.log('   --silent                Do not show anything');
+    console.log('   --verbose               Show detailed info about what it is doing');
     console.log('Experimental Options:');
     console.log('   --semi                  Toggle on the strict semicolon checking in Uglify');
     console.log('   --cache/--no-cache      Cache the results of the build and bail if building for no reason, defaults to --no-cache');

--- a/lib/index.js
+++ b/lib/index.js
@@ -121,6 +121,10 @@ exports.init = function (opts, initCallback) {
         log.silent();
     }
 
+    if (options.verbose) {
+        log.verbose();
+    }
+
     log.info('revving up');
     if (!options.walk) {
         log.info('looking for ' + buildFileName + ' file');

--- a/lib/log.js
+++ b/lib/log.js
@@ -8,6 +8,7 @@ var hasColor = process.stdin.isTTY;
 
 var quiet;
 var silent;
+var verbose;
 
 var prefix;
 
@@ -20,6 +21,10 @@ exports.quiet = function () {
 exports.silent = function () {
     silent = true;
     quiet = true;
+};
+
+exports.verbose = function () {
+    verbose = true;
 };
 
 exports.reset = function(options) {
@@ -40,13 +45,13 @@ exports.color = function (str, code) {
 
 
 exports.info = function (str) {
-    if (!quiet) {
+    if (verbose) {
         console.log(prefix, exports.color('[info]', 'white'), str);
     }
 };
 
 exports.log = function (str) {
-    if (!quiet) {
+    if (verbose) {
         console.log(prefix, exports.color('[queu]', 'cyan'), str);
     }
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "shifter",
     "description": "New YUI build tool based on Gearjs, so let's shift some gears",
     "author": "Dav Glass <davglass@gmail.com>",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "dependencies": {
         "progress": "~0.1.0",
         "ansi-color": "*",


### PR DESCRIPTION
In order to improve the signal to noise ratio of shifter,I added a `verbose` option to print `[info]` and `[queue]`
messages.

With this option, which defaults to false, those messages are no longer printed.

I felt those message were more useful to debug shifter itself than to those using shifter.

With less clutter on the report, the errors and warnings stand out much more.
