### PR TITLE
Lock istanbul to v0.1.37 to prevent breaking coverage comparison tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "cpr": "~0.0.6",
         "mkdirp": "*",
         "rimraf": "*",
-        "istanbul": "~0.1.8",
+        "istanbul": "0.1.37",
         "which": "*",
         "yuglify": "~0.1.0",
         "timethat": "~0.0.1",


### PR DESCRIPTION
I don't know what happened to istanbul's output in v0.1.38 ([v0.1.37...v0.1.38](https://github.com/gotwarlost/istanbul/compare/v0.1.37...v0.1.38)), but this resolves the incorrect test failures recent pull requests have been experiencing.
