### PR TITLE
Omit assets in non-skinnable builds when mod.assets === false

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -159,7 +159,7 @@ exports.start = function (json, options, buildCallback) {
 
     Object.keys(json.builds).forEach(function (name) {
         var mod = json.builds[name];
-        if (!mod.skinnable && !(mod.config && mod.config.skinnable)) {
+        if (!mod.skinnable && !(mod.config && mod.config.skinnable) && mod.assets !== false) {
             mod.assets = !hasSkin;
         }
         if (!options.modules || has(options.modules, name)) {

--- a/tests/5-builder.js
+++ b/tests/5-builder.js
@@ -102,6 +102,27 @@ var tests = {
                     'coverage should be same': function(err, results) {
                         assert.equal(results.pre['yql-coverage.js'], results.post['yql-coverage.js']);
                     }
+                },
+                'should respect mod.assets=false and': {
+                    topic: function() {
+                        var self = this;
+                        fs.stat(path.join(buildBase, 'yql', 'assets'), function (err) {
+                            self.callback(null, err);
+                        });
+                    },
+                    'should not create build/yql/assets': function(foo, err) {
+                        assert.isNotNull(err);
+                        assert.equal(err.code, 'ENOENT');
+                    }
+                },
+                'should copy assets in postbuild and': {
+                    topic: function() {
+                        fs.stat(path.join(buildBase, 'yql2', 'assets'), this.callback);
+                    },
+                    'should create build/yql2/assets': function(err, stat) {
+                        assert.isNull(err);
+                        assert.isTrue(stat.isDirectory());
+                    }
                 }
             }
         }

--- a/tests/6-builder-uglify-calendar.js
+++ b/tests/6-builder-uglify-calendar.js
@@ -178,6 +178,15 @@ function createTests(buildSkin) {
                                 assert.isTrue(stat.toString().indexOf('http://foobar.com/baz/calendar/assets/skins/sam/my-image.png') > -1);
                             }
                         };
+                        context['should create calendar-base/assets dir and'] = {
+                            topic: function() {
+                                fs.stat(path.join(buildBase, 'calendar-base', 'assets'), this.callback);
+                            },
+                            'should override mod.assets=false when skinnable': function(err, stat) {
+                                assert.isNull(err);
+                                assert.isTrue(stat.isDirectory());
+                            }
+                        };
                     } else {
                         context['should not create assets dir and'] = {
                             topic: function() {

--- a/tests/assets/yql/src/calendar/build.json
+++ b/tests/assets/yql/src/calendar/build.json
@@ -2,6 +2,7 @@
     "name": "calendar",
     "builds": {
         "calendar-base": {
+            "assets": false,
             "jsfiles": [
                 "calendar-base.js"
             ]

--- a/tests/assets/yql/src/yql/assets/foo.png
+++ b/tests/assets/yql/src/yql/assets/foo.png
@@ -1,0 +1,1 @@
+// totally an image

--- a/tests/assets/yql/src/yql/build.json
+++ b/tests/assets/yql/src/yql/build.json
@@ -5,6 +5,7 @@
     ],
     "builds": {
         "yql": {
+            "assets": false,
             "exec": [
                 "shifter --config test.json --no-global-config",
                 "echo 'Foobar'"

--- a/tests/assets/yql/src/yql/test.json
+++ b/tests/assets/yql/src/yql/test.json
@@ -5,6 +5,7 @@
     ],
     "builds": {
         "yql": {
+            "assets": false,
             "jsfiles": [
                 "yql.js"
             ]

--- a/tests/assets/yql/src/yql2/assets/foo.png
+++ b/tests/assets/yql/src/yql2/assets/foo.png
@@ -1,0 +1,1 @@
+// totally an image


### PR DESCRIPTION
When a module's build config includes the "assets" property set to `false`,
we should skip copying any existing assets folder for that build target.

However, if that module's meta.json includes the "skinnable" property set
to `true`, the assets directory will still be copied, as it is required by
the skinning pattern.

Fixes #87

(Until #91 is merged, Travis will fail for unrelated reasons)
