### PR TITLE
move `args.unshift(util.shifter)` out of walk.js's run() loop

### DIFF
--- a/lib/walk.js
+++ b/lib/walk.js
@@ -104,6 +104,8 @@ exports.run = function (options, callback) {
         log.info('using ' + args.join(' '));
     }
 
+    args.unshift(util.shifter);
+
     checkDirectory = function(startdir, workingdir) {
         fs.readdir(workingdir, modStack.add(function (err, dirs) {
             dirs.forEach(function (mod) {
@@ -144,7 +146,6 @@ exports.run = function (options, callback) {
             run = function () {
                 var mod = mods.pop(), child;
                 if (mod) {
-                    args.unshift(util.shifter);
                     child = spawn(process.execPath, args, {
                         cwd: path.join(shifter.cwd(), mod),
                         stdio: [process.stdin, 'ignore', process.stderr]


### PR DESCRIPTION
The path 'shifter/bin/shifter' was prepended to the spawn argument list
on each iteration of run(), which can be called many times in walk.js.
This grew the argument list. The extra args are ultimately ignored, but
this small fix prevents non-parsed arg pollution (i.e. the values nopt
returns in the parsed.remain property).
