### PR TITLE
Add support for coverage files relative to shifter config

### DIFF
--- a/conf/docs/index.mustache
+++ b/conf/docs/index.mustache
@@ -483,5 +483,12 @@ I've added a `--lint-stderr` config option which forces all lint output to `stde
 <h3 id="exp.cli.recursive">Recursive Building</h3>
 
 <p>
-    Adding `--recursive` to the `--walk` command will tell `shifter` to walk the directories recursively looking for `build.json` files. 
+    Adding `--recursive` to the `--walk` command will tell `shifter` to walk the directories recursively looking for `build.json` files.
 </p>
+<p>When building recursively, if you want to produce usable coverage instrumentation, you must also create a .shifter.json file with the coverageRelativeToConfig set to true.</p>
+
+```
+{
+  coverageRelativeToConfig: true
+}
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,6 +103,12 @@ exports.init = function (opts, initCallback) {
                         }
                     }
                 });
+
+                if (options.coverageRelativeToConfig) {
+                    // Since we found a path to the config file, we can build relative to it.
+                    // This is important for coverage reports in recursive builds.
+                    exports.relativeTo = path.resolve(path.dirname(file), './');
+                }
             }
         });
     }

--- a/lib/module.js
+++ b/lib/module.js
@@ -382,7 +382,15 @@ var buildCoverage = function (mod, name, callback) {
         logger: log,
         registry: registry
     }),
-        fileName = mod.basefilename || name;
+        fileName = mod.basefilename || name,
+        // The path to the build directory.
+        buildPath = 'build';
+    if (shifter.relativeTo) {
+        // If shifter is being run relative to a .shifter.json, we can make
+        // the coverage file report with relativity to that configuration.
+        // This is required in recursive builds for code coverage generation.
+        buildPath = path.relative(shifter.relativeTo, mod.buildDir);
+    }
 
     queue.read([
         path.join(mod.buildDir, fileName, fileName + '.js')
@@ -391,7 +399,7 @@ var buildCoverage = function (mod, name, callback) {
         .coverage({
             type: coverageType,
             charset: 'utf8',
-            name: 'build/' + fileName + '/' + fileName + '.js'
+            name: buildPath + '/' + fileName + '/' + fileName + '.js'
         })
         .replace(replaceOptions)
         .check()


### PR DESCRIPTION
I've recently been trying to build coverage reports from shifted modules and hit this issue on the way.
At present, all coverage files are built with the name and filename set as:

```
'build/' + filename + '/' + filename + '.js'
```

When istanbul then comes along to produce the report, it tries to find the source files at this path; however, when building in a recursive or distributed situation and where build is not in your immediate path, this leads to unresolvable .js files.

This change sets an internal relativeTo option to shifter which is then used when instrumenting the -coverage.js files so that each file is built relative to the configuration. This is only done when the configuration file:
- exists; and
- contains the parameter `coverageRelativeToConfig: true`

In a nested structure such as:

``` terminal
.
├── .shifter.json
└── path
    └── to
        └── yui
            ├── build
            │   └── somemodule
            │       ├── somemodule-coverage.js
            │       ├── somemodule-debug.js
            │       ├── somemodule-min.js
            │       └── somemodule.js
            └── src
                └── somemodule
                    ├── build.json
                    ├── js
                    │   └── somemodule.js
                    └── meta
                        └── somemodule.json
```

Instead of the path being set to:

```
build/somemodule/somemodule.js
```

It will be set to

```
path/to/yui/build/somemodule/somemodule.js
```

When it comes to creating the istanbul reports, this is now resolvable.
