### PR TITLE
Pass coverage option when walking

### DIFF
--- a/lib/walk.js
+++ b/lib/walk.js
@@ -62,6 +62,8 @@ exports.run = function (options, callback) {
     }
     if (options.coverage === false) {
         args.push('--no-coverage');
+    } else {
+        args.push('--coverage');
     }
     if (options.cache) {
         args.push('--cache');


### PR DESCRIPTION
At present, we generally don't want to generate coverage instrumentation, so we have:

```
{
  "coverage": false
}
```

set in our .shifter.json. However, as we begin to add unit tests, and extend our testing and build processes we need to be able to generate the coverage files as required.

We can do so by passing --coverage to shifter for individual builds, but this option is not passed to a shifted walk at present, only it's reverse.

This change explicitly sends either `--coverage` or `--no-coverage` depending on the calculated setting.
