### PR TITLE
Add support for coverage files relative to shifter config

### DIFF
--- a/conf/docs/index.mustache
+++ b/conf/docs/index.mustache
@@ -483,5 +483,12 @@ I've added a `--lint-stderr` config option which forces all lint output to `stde
 <h3 id="exp.cli.recursive">Recursive Building</h3>
 
 <p>
-    Adding `--recursive` to the `--walk` command will tell `shifter` to walk the directories recursively looking for `build.json` files. 
+    Adding `--recursive` to the `--walk` command will tell `shifter` to walk the directories recursively looking for `build.json` files.
 </p>
+<p>When building recursively, if you want to produce usable coverage instrumentation, you must also create a .shifter.json file with the coverageRelativeToConfig set to true.</p>
+
+```
+{
+  coverageRelativeToConfig: true
+}
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,6 +103,12 @@ exports.init = function (opts, initCallback) {
                         }
                     }
                 });
+
+                if (options.coverageRelativeToConfig) {
+                    // Since we found a path to the config file, we can build relative to it.
+                    // This is important for coverage reports in recursive builds.
+                    exports.relativeTo = path.resolve(path.dirname(file), './');
+                }
             }
         });
     }

--- a/lib/module.js
+++ b/lib/module.js
@@ -382,7 +382,15 @@ var buildCoverage = function (mod, name, callback) {
         logger: log,
         registry: registry
     }),
-        fileName = mod.basefilename || name;
+        fileName = mod.basefilename || name,
+        // The path to the build directory.
+        buildPath = 'build';
+    if (shifter.relativeTo) {
+        // If shifter is being run relative to a .shifter.json, we can make
+        // the coverage file report with relativity to that configuration.
+        // This is required in recursive builds for code coverage generation.
+        buildPath = path.relative(shifter.relativeTo, mod.buildDir);
+    }
 
     queue.read([
         path.join(mod.buildDir, fileName, fileName + '.js')
@@ -391,7 +399,7 @@ var buildCoverage = function (mod, name, callback) {
         .coverage({
             type: coverageType,
             charset: 'utf8',
-            name: 'build/' + fileName + '/' + fileName + '.js'
+            name: buildPath + '/' + fileName + '/' + fileName + '.js'
         })
         .replace(replaceOptions)
         .check()


### PR DESCRIPTION
Resubmitting this as a new pull request since github does not allow you to re-open requests.
This was #101 before. I've commented there and there is some additional detail not in this pull request.

This functionality is not covered by the build-dir option as suggested in the close comment. build-dir only makes the build relative. It doesn't change the coverage build options which are currently hardcoded as:
`'build/' + filename + '/' + filename + '.js'`

This means that it is not relative in a recursive build where the modules may be spread over many directories. For example, our module layout is:

``` terminal
2422 moodle:MDL-XXXXX-jsunit-m> find . -name 'yui'
./admin/tool/capability/yui
./admin/tool/installaddon/yui
./backup/util/ui/yui
./blocks/community/yui
./blocks/navigation/yui
./calendar/yui
./course/yui
./enrol/cohort/yui
./enrol/manual/yui
./enrol/yui
./filter/glossary/yui
./grade/grading/yui
./lib/editor/atto/plugins/bold/yui
./lib/editor/atto/plugins/clear/yui
./lib/editor/atto/plugins/html/yui
./lib/editor/atto/plugins/image/yui
./lib/editor/atto/plugins/indent/yui
./lib/editor/atto/plugins/italic/yui
./lib/editor/atto/plugins/link/yui
./lib/editor/atto/plugins/media/yui
./lib/editor/atto/plugins/orderedlist/yui
./lib/editor/atto/plugins/outdent/yui
./lib/editor/atto/plugins/strike/yui
./lib/editor/atto/plugins/title/yui
./lib/editor/atto/plugins/underline/yui
./lib/editor/atto/plugins/unlink/yui
./lib/editor/atto/plugins/unorderedlist/yui
./lib/editor/atto/yui
./lib/form/yui
./lib/yui
./lib/yuilib/3.9.1/build/yui
./mod/assign/yui
./mod/feedback/yui
./mod/quiz/yui
./theme/bootstrapbase/yui
```

We have src and build directories in all of these locations, but if we were to write tests and attempt to get coverage on them without this fix, the coverage instrumentation from istanbul would specify the source file relative to each yui directory, and not to the project root. For example, we have moodle-core-tooltip which I've been writing tests for:
`lib/yui/src/tooltip`; which builds into

`````` lib/yui/build/moodle-core-tooltip/moodle-core-tooltip.js```
However, the coverage __coverage__ variable write the path is:
```build/moodle-core-tooltip/moodle-core-tooltip.js```
Thus, when we pass it to grover across the entire project, the path is not found because it is incomplete.

The existing build-dir option cannot be used with a recursive build because it was changed to use path.resolve() recently and thus your builds end up in obscure locations not relevant to the src module depending on how you build (e.g. --walk vs from module vs --recursive).
``````
