### PR TITLE
Updating gear dependencies to fix broken shifter / gear-lib call to .replace()

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "progress": "~0.1.0",
         "ansi-color": "*",
-        "gear": "~0.7.0",
+        "gear": "~0.8.0",
         "gear-lib": "~0.8.0",
         "nopt": "*",
         "yuitest-coverage": ">=0.0.5",


### PR DESCRIPTION
This is to fix issue https://github.com/yui/shifter/issues/110

gear-lib v0.8.12 doesn't provide "replace" nor "stamp" anymore. Both methods are now moved to gear v0.8.16

Shifter on the other hand, requires gear "~0.7.0" and gear-lib "~0.8.0" which means that it actually (as of today) installs gear v0.7.16 and gear-lib v0.8.12 (which are now incompatible).

So when Shifter tries to call "replace", it just generates the following error:
/usr/local/lib/node_modules/shifter/lib/module.js:324
queue.replace(replaceOptions);
^
TypeError: Object # has no method 'replace'
at Object.buildJS
