### PR TITLE
Silent shifting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,6 @@ exports.init = function (opts, initCallback) {
     }
 
     if (options.silent) {
-        log.quiet();
         log.silent();
     }
     


### PR DESCRIPTION
--quiet should work on all calls to log.info ("Looking for nearest .shifter.json, woohoo, etc")
--silent should also call 'quiet'
