### PR TITLE
Lock the watch at 0.8.0, since 0.9.0 is not working for recursive watchi...

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "yuicompressor": "2.4.7",
         "yui-lint": "~0.1.1",
         "jshint": "~0.9.0",
-        "watch": "*",
+        "watch": "~0.8.0",
         "cpr": "~0.0.6",
         "mkdirp": "*",
         "rimraf": "*",


### PR DESCRIPTION
The recursive watch is not functioning correctly with the newest watch version (currently 0.9.0).

This fix locks the version to 0.8.0 in order to guarantee its functioning.
