### PR TITLE
making sure that execution of scripts defined in build.json->exec are calling back into the main execution path

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -110,7 +110,7 @@ exports.start = function (json, options, buildCallback) {
         log.info('found a prebuild, shifting it');
         prebuild(json.prebuilds, options, function () {
             delete json.prebuilds;
-            exports.start(json, options);
+            exports.start(json, options, buildCallback);
         });
         return;
     }
@@ -136,13 +136,13 @@ exports.start = function (json, options, buildCallback) {
                     pack.munge(json2, options, function (json2, options) {
                         delete json2.exec;
                         delete json2.prebuilds;
-                        exports.start(json2, options);
+                        exports.start(json2, options, buildCallback);
                     });
                 } else {
                     log.error('hitting the brakes, your ' + options.buildFileName + ' file is invalid, please fix it!');
                 }
             } else {
-                exports.start(json, options);
+                exports.start(json, options, buildCallback);
             }
         });
         return;


### PR DESCRIPTION
If you're using `require('shifter').add()` to add new files into the queue to be executed, and you use `exec`, shifter will exit without continuing the execution of the queue. This patch fix that. Here is an example file:

```
{
    "name": "stencil",
    "exec": ["./resources/shifter_exec.js"],
    "builds": {
        "stencil-css": {
            "cssfiles": [
                "dist/base.css",
                "dist/grid.css",
                "dist/grid-responsive.css",
                "dist/table.css",
                "dist/skins.css",
                "dist/components.css",
                "dist/helpers.css",
                "dist/declarations.css",
                "dist/fx.css"
            ],
            "assets": true
        }
    },
    "shifter": {
        "coverage": false,
        "lint": false
    }
}
```
