### PR TITLE
Child shifter runs should only use the arguments provided

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -67,6 +67,34 @@ var clean = function(args) {
     return parsed;
 };
 
+// Get the base arguments list without defaults applied.
+var baseOptions = function(args) {
+    var options = {},
+        key;
+
+    // Get any supplied arguments if not specified.
+    if (!args) {
+        args = clean();
+    }
+
+    // Define all of the base arguments.
+    for (key in known) {
+        if (known.hasOwnProperty(key)) {
+            options[key] = undefined;
+        }
+    }
+
+    // Add any supplied overrides.
+    for (key in args) {
+        // And override with the specified arguments.
+        if (args.hasOwnProperty(key)) {
+            options[key] = args[key];
+        }
+    }
+
+    return options;
+};
+
 var setDefaults = function(parsed) {
     if (parsed === undefined) {
         parsed = clean();
@@ -113,6 +141,7 @@ var parse = function (args) {
 };
 
 exports.defaults = setDefaults;
+exports.baseOptions = baseOptions;
 exports.has = has;
 exports.raw = raw;
 exports.parse = parse;

--- a/lib/index.js
+++ b/lib/index.js
@@ -200,7 +200,9 @@ exports.init = function (opts, initCallback) {
         } else {
             if (options.walk) {
                 walk = require('./walk');
-                walk.run(options, initCallback);
+                // Use the less-processed opts here instead - we don't want the defaults to override the individual
+                // Shifter configurations.
+                walk.run(args.baseOptions(opts), initCallback);
             } else {
                 log.warn('no ' + buildFileName + ' file, downshifting to convert ant files');
                 ant = require('./ant');

--- a/tests/1-args.js
+++ b/tests/1-args.js
@@ -265,6 +265,41 @@ var tests = {
             assert.isFalse(topic.quiet);
             assert.isFalse(topic.cache);
         }
+    },
+    'args.baseOptions should define all of the standard options': {
+        topic: function() {
+            return args.baseOptions();
+        },
+        'should default undefined': function(topic) {
+            assert.isTrue(topic.hasOwnProperty('walk') && topic.walk === undefined);
+            assert.isTrue(topic.hasOwnProperty('cache') && topic.cache === undefined);
+            assert.isTrue(topic.hasOwnProperty('lint') && topic.lint === undefined);
+        },
+        'should not have undefined values': function(topic) {
+            assert.isFalse(topic.hasOwnProperty('foo'));
+            assert.isFalse(topic.hasOwnProperty('bar'));
+            assert.isFalse(topic.hasOwnProperty('baz'));
+        }
+    },
+    'args.baseOptions should allow CLI overrides of options': {
+        topic: function() {
+            return args.baseOptions({
+                cache: true,
+                lint: 'config'
+            });
+        },
+        'should allow overrides': function(topic) {
+            assert.isTrue(topic.cache);
+            assert.equal('config', topic.lint);
+        },
+        'should default undefined': function(topic) {
+            assert.isTrue(topic.hasOwnProperty('walk') && topic.walk === undefined);
+        },
+        'should not have undefined values': function(topic) {
+            assert.isFalse(topic.hasOwnProperty('foo'));
+            assert.isFalse(topic.hasOwnProperty('bar'));
+            assert.isFalse(topic.hasOwnProperty('baz'));
+        }
     }
 };
 


### PR DESCRIPTION
When spawning a child Shifter run, we should not pass the child all of the 
default arguments as these will override any specified in the build.json.
