### PR TITLE
Check the size of source files in the output file size check

### DIFF
--- a/lib/tasks/check.js
+++ b/lib/tasks/check.js
@@ -3,12 +3,21 @@ Copyright (c) 2012, Yahoo! Inc. All rights reserved.
 Code licensed under the BSD License:
 http://yuilibrary.com/license/
 */
+var fs = require('fs');
 
 exports.check = function (options, blob, done) {
-    var bail = null;
+    var bail = null,
+        sourceFile;
 
     if (blob.result.length === 0) {
-        bail = 'writing zero length file from ' + blob.name;
+        if (blob.name) {
+            sourceFile = fs.readFileSync(blob.name, {
+                encoding: 'UTF-8'
+            });
+        }
+        if (!blob.name || sourceFile.length !== 0) {
+            bail = 'writing zero length file from ' + blob.name;
+        }
     }
 
     done(bail, new blob.constructor(blob.result, blob));


### PR DESCRIPTION
This checks the size of the source file when the output file is empty and allows a clean build on master again.

Addresses issues revealed by #118 and discussed in #120.
