### PR TITLE
Changing "cant find meta directory" log to info

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -85,7 +85,7 @@ exports.munge = function (json, options, callback) {
                 }
             }
         } else {
-            log.warn('down shifting, can\'t find a meta directory');
+            log.info('down shifting, can\'t find a meta directory');
         }
         //Cleanup..
         Object.keys(json.builds).forEach(function (name) {


### PR DESCRIPTION
@caridy

I see this message a lot when shifter runs but I think it should not be a warning. Is there an issue if there is no meta directory found? I'd prefer to keep that under the "quiet" flag, since silent shows warn and errors.
