### PR TITLE
Use global excludes option when walking.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -214,9 +214,9 @@ exports.init = function (opts, initCallback) {
         } else {
             if (options.walk) {
                 walk = require('./walk');
-                // Use the less-processed opts here instead - we don't want the defaults to override the individual
+                // Also provide the less-processed opts here - we don't want the defaults to override the individual
                 // Shifter configurations.
-                walk.run(args.baseOptions(opts), initCallback);
+                walk.run(options, args.baseOptions(opts), initCallback);
             } else {
                 log.warn('no ' + buildFileName + ' file, downshifting to convert ant files');
                 ant = require('./ant');

--- a/lib/walk.js
+++ b/lib/walk.js
@@ -14,7 +14,7 @@ var log = require('./log'),
         });
     };
 
-exports.run = function (options, callback) {
+exports.run = function (fullOptions, options, callback) {
     if (!log.isTTY) {
         options.progress = false;
     }
@@ -30,8 +30,10 @@ exports.run = function (options, callback) {
         args = [],
         checkDirectory;
 
-    if (options.excludes && options.excludes.length) {
-        options.excludes.forEach(function(mod) {
+    // The excludes come from the full options in a walk as they are calculated outside the walk itself and are not
+    // appended to the walk options.
+    if (fullOptions.excludes && fullOptions.excludes.length) {
+        fullOptions.excludes.forEach(function(mod) {
             excludes[mod] = mod;
         });
     }


### PR DESCRIPTION
The excludes option only makes sense at the walk level, so needs to be
separate to the child options, but it also must be respected within walk.js
therefore I have passed it as an additional argument into walk/run()

This has come up as we are in the process of migrating from shifter to
grunt-based tools and during the transition we need to ensure that running
shifter will not cause the node_modules directory to be built too.
